### PR TITLE
Adds Paper Cup crafting recipe

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -967,3 +967,12 @@
 				/obj/item/aquarium_kit = 1
 				)
 	category = CAT_MISC
+	
+	/datum/crafting_recipe/paper_cup
+	name= "Paper Cup"
+	result = /obj/item/reagent_containers/food/drinks/sillycup
+	time = 10
+	reqs = list(/obj/item/paper = 1)
+	category = CAT_MISC
+	tools = list(TOOL_WIRECUTTER)
+


### PR DESCRIPTION


## About The Pull Request
Adds paper cups to the crafting menu.
Requires 1 sheet of paper and wirecutters to crimp it into shape.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Currently no way to manufacture nor buy paper cups and supply is extremely limited and generally unknown (water coolers have 25).
Makes snow cone crafting more viable in turn.

## Changelog
:cl:
add: Adds Paper Cups to the Misc crafting tab
/:cl:
